### PR TITLE
Move images and versions to variables.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,24 @@
 ---
 
+#
+# container image settings
+#
+
+awx_awxweb_version: 9.2.0
+awx_awxtask_version: 9.2.0
+awx_postgres_version: 9.6
+awx_rabbitmq_version: 3.7.21
+
+awx_awxweb_image: docker.io/ansible/awx_web:{{ awx_awxweb_version }}
+awx_awxtask_image: docker.io/ansible/awx_task:{{ awx_awxtask_version }}
+awx_postgres_image: docker.io/library/postgres:{{ awx_postgres_version }}
+awx_rabbitmq_image: docker.io/ansible/awx_rabbitmq:{{ awx_rabbitmq_version }}
+awx_memcached_image: docker.io/library/memcached:alpine
+
+#
+# awx host settings
+#
+
 awx_admin_user: admin
 awx_admin_password: password
 

--- a/templates/awx.yml.j2
+++ b/templates/awx.yml.j2
@@ -43,7 +43,7 @@ spec:
       value: /var/lib/postgresql/data/pgdata
     - name: POSTGRES_PASSWORD
       value: {{ awx_postgres_password }}
-    image: docker.io/library/postgres:{{ awx_postgres_version }}
+    image: {{ awx_postgres_image }}
     name: postgres
     volumeMounts:
     - mountPath: /var/lib/postgresql/data/pgdata:z
@@ -55,7 +55,7 @@ spec:
     - docker-entrypoint.sh
     - memcached
     env:
-    image: docker.io/library/memcached:alpine
+    image: {{ awx_memcached_image }}
     name: memcached
   #
   # awx-web container
@@ -99,7 +99,7 @@ spec:
       value: 127.0.0.1
     - name: MEMCACHED_PORT
       value: "11211"
-    image: docker.io/ansible/awx_web:{{ awx_awxweb_version }}
+    image: {{ awx_awxweb_image }}
     name: awxweb
     workingDir: /var/lib/awx
     volumeMounts:
@@ -157,7 +157,7 @@ spec:
       value: 127.0.0.1
     - name: MEMCACHED_PORT
       value: "11211"
-    image: docker.io/ansible/awx_task:{{ awx_awxtask_version }}
+    image: {{ awx_awxtask_image }}
     name: awxtask
     workingDir: /var/lib/awx
     volumeMounts:
@@ -185,5 +185,5 @@ spec:
       value: {{ awx_rabbitmq_user }}
     - name: RABBITMQ_DEFAULT_PASS
       value: {{ awx_rabbitmq_password }}
-    image: docker.io/ansible/awx_rabbitmq:{{ awx_rabbitmq_version }}
+    image: {{ awx_rabbitmq_image }}
     name: rabbitmq

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -7,14 +7,9 @@ awx_pod_yaml_path: "{{ awx_pod_yaml_dir }}/{{ awx_pod_yaml_file }}"
 
 awx_pod_label: "{{ awx_pod_name }}"
 
-awx_awxweb_version: 9.1.1
-awx_awxtask_version: 9.1.1
-awx_postgres_version: 9.6
-awx_rabbitmq_version: 3.7.21
-
 awx_container_image_list:
-  - "docker.io/library/postgres:{{ awx_postgres_version }}"
-  - "docker.io/library/memcached:alpine"
-  - "docker.io/ansible/awx_rabbitmq:{{ awx_rabbitmq_version }}"
-  - "docker.io/ansible/awx_web:{{ awx_awxweb_version }}"
-  - "docker.io/ansible/awx_task:{{ awx_awxtask_version }}"
+  - "{{ awx_postgres_image }}"
+  - "{{ awx_memcached_image }}"
+  - "{{ awx_rabbitmq_image }}"
+  - "{{ awx_awxweb_image }}"
+  - "{{ awx_awxtask_image }}"


### PR DESCRIPTION
This patch adds support for custom/derived container images
which might be necessary when using e.g. custom virtualenvs in awx.