### PR TITLE
Update defaults for awx 9.3

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,9 +4,9 @@
 # container image settings
 #
 
-awx_awxweb_version: 9.2.0
-awx_awxtask_version: 9.2.0
-awx_postgres_version: 9.6
+awx_awxweb_version: 9.3.0
+awx_awxtask_version: 9.3.0
+awx_postgres_version: 10
 awx_rabbitmq_version: 3.7.21
 
 awx_awxweb_image: docker.io/ansible/awx_web:{{ awx_awxweb_version }}


### PR DESCRIPTION
You also had an old postgres container, awx uses 10 since a couple of versions (8.0?).

I noticed awx does not use the rabbitmq container you specify but rather an older version:
https://github.com/ansible/awx/blob/devel/installer/roles/local_docker/defaults/main.yml#L4

I did not change that, the newer version seems to work.
