### PR TITLE
Prefix all role vars in a consistent way with "awx_"

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Example Playbook
   tasks:
     - name: import awx_pod role to install it all
       vars:
-        admin_user: admin
-        admin_password: foobar
+        awx_admin_user: admin
+        awx_admin_password: foobar
         awx_podman_dir: /tmp
         awx_host_port: 8052
-        container_state: running
+        awx_container_state: running
       import_role:
         name: awx_pod
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Example Playbook
         awx_admin_password: foobar
         awx_podman_dir: /tmp
         awx_host_port: 8052
-        awx_container_state: running
+        container_state: running
       import_role:
         name: awx_pod
 ```

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,9 +21,9 @@ awx_postgres_update: False
 # awx host settings
 #
 
-admin_user: admin
-admin_email: 'root@localhost'
-admin_password: password
+awx_admin_user: admin
+awx_admin_password: password
+awx_server_email: 'root@localhost'
 
 awx_pod_name: awx
 awx_pod_label: awx
@@ -35,29 +35,29 @@ awx_host_ssl_port: 443
 
 # Optional SSL stuff, the files are copied from the server you run ansible from.
 # (ansible copy src)
-# ssl_certificate: /etc/cockpit/ws-certs.d/0-self-signed.cert
-# ca_trust_file: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+# awx_host_ssl_certificate: /etc/cockpit/ws-certs.d/0-self-signed.cert
+# awx_host_ssl_ca_trust_file: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 #
 # anything below is pod internal info, never seen outside.
 #
-pg_hostname: localhost
-pg_port: 5432
-pg_database: awx
-pg_username: awx
-pg_password: awxpass
-
 awx_secret_key: iamverysecret
 
-memcached_hostname: localhost
-memcached_port: 11211
-memcached_mem_request: 1
-memcached_cpu_request: 500
+awx_pg_hostname: localhost
+awx_pg_port: 5432
+awx_pg_database: awx
+awx_pg_username: awx
+awx_pg_password: awxpass
+
+awx_memcached_hostname: localhost
+awx_memcached_port: 11211
+awx_memcached_mem_request: 1
+awx_memcached_cpu_request: 500
 
 # for settings file
-task_mem_request: 2
-task_cpu_request: 1500
-automation_analytics_url: "https://example.org"
-insights_url_base: "https://example.org"
-insights_agent_mime: "application/example"
-container_groups_image: "ansible/ansible-runner"
+awx_task_mem_request: 2
+awx_task_cpu_request: 1500
+awx_automation_analytics_url: "https://example.org"
+awx_insights_url_base: "https://example.org"
+awx_insights_agent_mime: "application/example"
+awx_container_groups_image: "ansible/ansible-runner"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,7 +113,7 @@
       mode: '0600'
       owner: '1000'
 
-  when: awx_container_state == 'running'
+  when: container_state == 'running'
 
 - name: import role podman_container_systemd to handle containers
   vars:
@@ -128,10 +128,10 @@
   file:
     path: "{{ awx_pod_yaml_path }}"
     state: absent
-  when: awx_container_state == 'absent'
+  when: container_state == 'absent'
 
 - name: "remove awx config file directory: {{ awx_podman_dir }}"
   file:
     path: "{{ awx_podman_dir }}/"
     state: absent
-  when: awx_container_state == 'absent'
+  when: container_state == 'absent'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
     _container_firewall_ports:
       - "{{ awx_host_port }}/tcp"
       - "{{ awx_host_ssl_port }}/tcp"
-  when: ssl_certificate is defined
+  when: awx_host_ssl_certificate is defined
 
 - name: do preparations for running pod
   block:
@@ -79,11 +79,11 @@
 
   - name: copy ssl certificate
     copy:
-      src: "{{ ssl_certificate }}"
+      src: "{{ awx_host_ssl_certificate }}"
       dest: "{{ awx_podman_dir }}/awxweb.pem"
       mode: '0600'
       owner: '1000'
-    when: ssl_certificate is defined
+    when: awx_host_ssl_certificate is defined
 
   - name: template ngnix.conf
     template:
@@ -113,7 +113,7 @@
       mode: '0600'
       owner: '1000'
 
-  when: container_state == 'running'
+  when: awx_container_state == 'running'
 
 - name: import role podman_container_systemd to handle containers
   vars:
@@ -128,10 +128,10 @@
   file:
     path: "{{ awx_pod_yaml_path }}"
     state: absent
-  when: container_state == 'absent'
+  when: awx_container_state == 'absent'
 
 - name: "remove awx config file directory: {{ awx_podman_dir }}"
   file:
     path: "{{ awx_podman_dir }}/"
     state: absent
-  when: container_state == 'absent'
+  when: awx_container_state == 'absent'

--- a/templates/awx.yml.j2
+++ b/templates/awx.yml.j2
@@ -21,10 +21,10 @@ spec:
     hostPath:
       path: {{ awx_podman_dir }}/redis-socket
       type: Directory
-{% if ca_trust_file is defined %}
+{% if awx_host_ssl_ca_trust_file is defined %}
   - name: ca_trust_file
     hostPath:
-      path: {{ ca_trust_file }}
+      path: {{ awx_host_ssl_ca_trust_file }}
       type: File
 {% endif %}
   - name: awx-secret
@@ -51,7 +51,7 @@ spec:
     hostPath:
       path: {{ awx_podman_dir }}/credentials.py
       type: File
-{% if ssl_certificate is defined %}
+{% if awx_host_ssl_certificate is defined %}
   - name: ssl_certificate
     hostPath:
       path: {{ awx_podman_dir }}/awxweb.pem
@@ -65,13 +65,13 @@ spec:
     - run-postgresql
     env:
     - name: POSTGRESQL_USER
-      value: {{ pg_username }}
+      value: {{ awx_pg_username }}
     - name: POSTGRESQL_DATABASE
-      value: {{ pg_database }}
+      value: {{ awx_pg_database }}
     - name: PGDATA
       value: /var/lib/pgsql/data
     - name: POSTGRESQL_PASSWORD
-      value: {{ pg_password }}
+      value: {{ awx_pg_password }}
 {% if awx_postgres_update %}
     - name: POSTGRESQL_UPGRADE
       value: copy
@@ -99,25 +99,25 @@ spec:
     - /usr/bin/launch_awx.sh
     env:
     - name: AWX_ADMIN_USER
-      value: {{ admin_user }}
+      value: {{ awx_admin_user }}
     - name: AWX_ADMIN_PASSWORD
-      value: {{ admin_password }}
+      value: {{ awx_admin_password }}
     - name: HOSTNAME
       value: {{ awx_pod_name }}
     - name: DATABASE_NAME
-      value: {{ pg_database }}
+      value: {{ awx_pg_database }}
     - name: DATABASE_USER
-      value: {{ pg_username }}
+      value: {{ awx_pg_username }}
     - name: DATABASE_PASSWORD
-      value: {{ pg_password }}
+      value: {{ awx_pg_password }}
     - name: DATABASE_PORT
-      value: {{ pg_port }}
+      value: {{ awx_pg_port }}
     - name: DATABASE_HOST
-      value: {{ pg_hostname }}
+      value: {{ awx_pg_hostname }}
     - name: MEMCACHED_HOST
-      value: {{ memcached_hostname }}
+      value: {{ awx_memcached_hostname }}
     - name: MEMCACHED_PORT
-      value: {{ memcached_port }}
+      value: {{ awx_memcached_port }}
     image: {{ awx_awxweb_image }}
     name: {{ awx_pod_name }}_awxweb
     workingDir: /var/lib/awx
@@ -126,7 +126,7 @@ spec:
       name: awx-data-volume
     - mountPath: /var/run/redis:z
       name: redis-volume
-{% if ca_trust_file is defined %}
+{% if awx_host_ssl_ca_trust_file is defined %}
     - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:z
       name: ca_trust_file
       readOnly: true
@@ -146,7 +146,7 @@ spec:
     - mountPath: /etc/tower/conf.d/credentials.py:z
       name: credentials-py
       readOnly: true
-{% if ssl_certificate is defined %}
+{% if awx_host_ssl_certificate is defined %}
     - mountPath: /etc/nginx/awxweb.pem:z
       name: ssl_certificate
       readOnly: true
@@ -155,7 +155,7 @@ spec:
       - containerPort: 8052
         hostPort: {{ awx_host_port }}
         protocol: TCP
-{% if ssl_certificate is defined %}
+{% if awx_host_ssl_certificate is defined %}
       - containerPort: 8053
         hostPort: {{ awx_host_ssl_port }}
         protocol: TCP
@@ -169,25 +169,25 @@ spec:
     - /usr/bin/launch_awx_task.sh
     env:
     - name: AWX_ADMIN_USER
-      value: {{ admin_user }}
+      value: {{ awx_admin_user }}
     - name: AWX_ADMIN_PASSWORD
-      value: {{ admin_password }}
+      value: {{ awx_admin_password }}
     - name: HOSTNAME
       value: {{ awx_pod_name }}
     - name: DATABASE_NAME
-      value: {{ pg_database }}
+      value: {{ awx_pg_database }}
     - name: DATABASE_USER
-      value: {{ pg_username }}
+      value: {{ awx_pg_username }}
     - name: DATABASE_PASSWORD
-      value: {{ pg_password }}
+      value: {{ awx_pg_password }}
     - name: DATABASE_PORT
-      value: {{ pg_port }}
+      value: {{ awx_pg_port }}
     - name: DATABASE_HOST
-      value: {{ pg_hostname }}
+      value: {{ awx_pg_hostname }}
     - name: MEMCACHED_HOST
-      value: {{ memcached_hostname }}
+      value: {{ awx_memcached_hostname }}
     - name: MEMCACHED_PORT
-      value: {{ memcached_port }}
+      value: {{ awx_memcached_port }}
     image: {{ awx_awxtask_image }}
     name: {{ awx_pod_name }}_awxtask
     workingDir: /var/lib/awx
@@ -198,7 +198,7 @@ spec:
       name: awx-data-volume
     - mountPath: /var/run/redis:z
       name: redis-volume
-{% if ca_trust_file is defined %}
+{% if awx_host_ssl_ca_trust_file is defined %}
     - mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem:z
       name: ca_trust_file
       readOnly: true
@@ -218,7 +218,7 @@ spec:
     - mountPath: /etc/tower/conf.d/credentials.py:z
       name: credentials-py
       readOnly: true
-{% if ssl_certificate is defined %}
+{% if awx_host_ssl_certificate is defined %}
     - mountPath: /etc/nginx/awxweb.pem:z
       name: ssl_certificate
       readOnly: true

--- a/templates/credentials.py.j2
+++ b/templates/credentials.py.j2
@@ -2,18 +2,18 @@ DATABASES = {
     'default': {
         'ATOMIC_REQUESTS': True,
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': "{{ pg_database }}",
-        'USER': "{{ pg_username }}",
-        'PASSWORD': "{{ pg_password }}",
-        'HOST': "{{ pg_hostname }}",
-        'PORT': "{{ pg_port }}",
+        'NAME': "{{ awx_pg_database }}",
+        'USER': "{{ awx_pg_username }}",
+        'PASSWORD': "{{ awx_pg_password }}",
+        'HOST': "{{ awx_pg_hostname }}",
+        'PORT': "{{ awx_pg_port }}",
     }
 }
 
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': '{}:{}'.format("{{ memcached_hostname }}", "{{ memcached_port }}")
+        'LOCATION': '{}:{}'.format("{{ awx_memcached_hostname }}", "{{ awx_memcached_port }}")
     },
     'ephemeral': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',

--- a/templates/environment.sh.j2
+++ b/templates/environment.sh.j2
@@ -1,7 +1,7 @@
-DATABASE_USER={{ pg_username }}
-DATABASE_NAME={{ pg_database }}
-DATABASE_HOST={{ pg_hostname }}
-DATABASE_PORT={{ pg_port }}
-DATABASE_PASSWORD={{ pg_password | quote }}
-MEMCACHED_HOST={{ memcached_hostname }}
-MEMCACHED_PORT={{ memcached_port }}
+DATABASE_USER={{ awx_pg_username }}
+DATABASE_NAME={{ awx_pg_database }}
+DATABASE_HOST={{ awx_pg_hostname }}
+DATABASE_PORT={{ awx_pg_port }}
+DATABASE_PASSWORD={{ awx_pg_password | quote }}
+MEMCACHED_HOST={{ awx_memcached_hostname }}
+MEMCACHED_PORT={{ awx_memcached_port }}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -36,7 +36,7 @@ http {
         server 127.0.0.1:8051;
     }
 
-    {% if ssl_certificate is defined %}
+    {% if awx_host_ssl_certificate is defined %}
     server {
         listen 8052 default_server;
         server_name _;
@@ -47,7 +47,7 @@ http {
     {%endif %}
 
     server {
-        {% if ssl_certificate is defined %}
+        {% if awx_host_ssl_certificate is defined %}
         listen 8053 ssl;
 
         ssl_certificate /etc/nginx/awxweb.pem;

--- a/templates/settings.py.j2
+++ b/templates/settings.py.j2
@@ -7,17 +7,17 @@ AWX_PROOT_ENABLED = False
 # Automatically deprovision pods that go offline
 AWX_AUTO_DEPROVISION_INSTANCES = True
 
-SYSTEM_TASK_ABS_CPU = {{ ((task_cpu_request|int / 1000) * 4)|int }}
-SYSTEM_TASK_ABS_MEM = {{ ((task_mem_request|int * 1024) / 100)|int }}
+SYSTEM_TASK_ABS_CPU = {{ ((awx_task_cpu_request|int / 1000) * 4)|int }}
+SYSTEM_TASK_ABS_MEM = {{ ((awx_task_mem_request|int * 1024) / 100)|int }}
 
-{% if ssl_certificate is defined %}
+{% if awx_host_ssl_certificate is defined %}
 TOWER_URL_BASE = "https://{{ ansible_fqdn }}:{{ awx_host_ssl_port }}"
 {% else %}
 TOWER_URL_BASE = "http://{{ ansible_fqdn }}:{{ awx_host_port }}"
 {% endif %}
-INSIGHTS_URL_BASE = "{{ insights_url_base }}"
-INSIGHTS_AGENT_MIME = "{{ insights_agent_mime }}"
-AUTOMATION_ANALYTICS_URL = "{{ automation_analytics_url }}"
+INSIGHTS_URL_BASE = "{{ awx_insights_url_base }}"
+INSIGHTS_AGENT_MIME = "{{ awx_insights_agent_mime }}"
+AUTOMATION_ANALYTICS_URL = "{{ awx_automation_analytics_url }}"
 
 #Autoprovisioning should replace this
 CLUSTER_HOST_ID = socket.gethostname()
@@ -34,7 +34,7 @@ JOBOUTPUT_ROOT = '/var/lib/awx/job_status'
 SECRET_KEY = open('/etc/tower/SECRET_KEY', 'rb').read().strip()
 ALLOWED_HOSTS = ['*']
 INTERNAL_API_URL = 'http://127.0.0.1:8052'
-SERVER_EMAIL = 'root@localhost'
+SERVER_EMAIL = '{{ awx_server_email }}'
 DEFAULT_FROM_EMAIL = 'webmaster@localhost'
 EMAIL_SUBJECT_PREFIX = '[AWX] '
 EMAIL_HOST = 'localhost'
@@ -72,7 +72,7 @@ LOGGING['handlers']['management_playbooks'] = {'class': 'logging.NullHandler'}
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': '{}:{}'.format("{{ memcached_hostname }}", "{{ memcached_port }}")
+        'LOCATION': '{}:{}'.format("{{ awx_memcached_hostname }}", "{{ awx_memcached_port }}")
     },
     'ephemeral': {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
@@ -81,7 +81,7 @@ CACHES = {
 
 USE_X_FORWARDED_PORT = True
 
-AWX_CONTAINER_GROUP_DEFAULT_IMAGE = "{{ container_groups_image }}"
+AWX_CONTAINER_GROUP_DEFAULT_IMAGE = "{{ awx_container_groups_image }}"
 REDHAT_CANDLEPIN_HOST = "{{ candlepin_host  | default(omit) }}"
 REDHAT_CANDLEPIN_VERIFY = "{{ candlepin_verify | default(omit) }}"
 BROADCAST_WEBSOCKET_PORT = 8052

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -8,7 +8,7 @@
         awx_admin_user: admin
         awx_admin_password: foobar
         awx_podman_dir: /tmp
-        #awx_container_state: absent or running
+        #container_state: absent or running
       import_role:
         name: awx_pod
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,10 +5,10 @@
   tasks:
     - name: import awx_pod role to install it all
       vars:
-        admin_user: admin
-        admin_password: foobar
+        awx_admin_user: admin
+        awx_admin_password: foobar
         awx_podman_dir: /tmp
-        #container_state: absent or running
+        #awx_container_state: absent or running
       import_role:
         name: awx_pod
 


### PR DESCRIPTION
In order to make clear that all the role-depending vars belong to that role I prefixed them all with a "awx_".

Additionally I added the `awx_server_email` variable.