### PR TITLE
Awx 13

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,12 +4,13 @@
 # container image settings
 #
 
-awx_awxweb_version: 11.0.0
-awx_awxtask_version: 11.0.0
+awx_awx_version: 13.0.0
+awx_awxweb_version: "{{ awx_awx_version }}"
+awx_awxtask_version: "{{ awx_awx_version }}"
 awx_postgres_version: 10
 
-awx_awxweb_image: docker.io/ansible/awx_web:{{ awx_awxweb_version }}
-awx_awxtask_image: docker.io/ansible/awx_task:{{ awx_awxtask_version }}
+awx_awxweb_image: "{{ awx_awx_image | default('docker.io/ansible/awx:{}'.format(awx_awxweb_version)) }}"
+awx_awxtask_image: "{{ awx_awx_image | default('docker.io/ansible/awx:{}'.format(awx_awxtask_version)) }}"
 awx_postgres_image: docker.io/centos/postgresql-{{ awx_postgres_version }}-centos7
 awx_memcached_image: docker.io/library/memcached:alpine
 awx_redis_image: docker.io/library/redis:latest

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,8 +4,8 @@
 # container image settings
 #
 
-awx_awxweb_version: 10.0.0
-awx_awxtask_version: 10.0.0
+awx_awxweb_version: 11.0.0
+awx_awxtask_version: 11.0.0
 awx_postgres_version: 10
 
 awx_awxweb_image: docker.io/ansible/awx_web:{{ awx_awxweb_version }}
@@ -49,10 +49,13 @@ awx_pg_database: awx
 awx_pg_username: awx
 awx_pg_password: awxpass
 
-awx_memcached_hostname: localhost
-awx_memcached_port: 11211
+
 awx_memcached_mem_request: 1
 awx_memcached_cpu_request: 500
+awx_memcached_socket_path: /var/run/memcached
+awx_memcached_socket_filename: memcached.sock
+
+awx_kubernetes_redis_config_mount_path: /usr/local/etc/redis/redis.conf
 
 # for settings file
 awx_task_mem_request: 2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,6 +63,34 @@
       mode: '0777'
       owner: '999'
 
+  - name: ensure awx memcached-socket directory exists
+    file:
+      path: "{{ awx_podman_dir }}/memcached-socket"
+      state: directory
+      mode: '0777'
+      owner: '1000'
+
+  - name: ensure awx supervisor-socket directory exists
+    file:
+      path: "{{ awx_podman_dir }}/supervisor-socket"
+      state: directory
+      mode: '0700'
+      owner: '1000'
+
+  - name: ensure awx rsyslog-socket directory exists
+    file:
+      path: "{{ awx_podman_dir }}/rsyslog-socket"
+      state: directory
+      mode: '0700'
+      owner: '1000'
+
+  - name: ensure awx rsyslog directory exists
+    file:
+      path: "{{ awx_podman_dir }}/rsyslog-dir"
+      state: directory
+      mode: '0700'
+      owner: '1000'
+
   - name: copy awx SECRET_FILE
     copy:
       content: "{{ awx_secret_key }}"

--- a/templates/awx.yml.j2
+++ b/templates/awx.yml.j2
@@ -9,6 +9,22 @@ spec:
   # define exported volumes for permanent data
   #
   volumes:
+  - name: supervisor-socket
+    hostPath:
+      path: {{ awx_podman_dir }}/supervisor-socket
+      type: Directory
+  - name: rsyslog-socket
+    hostPath:
+      path: {{ awx_podman_dir }}/rsyslog-socket
+      type: Directory
+  - name: rsyslog-dir
+    hostPath:
+      path: {{ awx_podman_dir }}/rsyslog-dir
+      type: Directory
+  - name: memcached-socket
+    hostPath:
+      path: {{ awx_podman_dir }}/memcached-socket
+      type: Directory
   - name: awx-data-volume
     hostPath:
       path: {{ awx_podman_dir }}/data
@@ -85,11 +101,17 @@ spec:
   # memcached container
   #
   - command:
-    - docker-entrypoint.sh
     - memcached
+    - -s
+    - {{ memcached_socket_path }}/{{ memcached_socket_filename }}
+    - -a
+    - 0666
     env:
     image: {{ awx_memcached_image }}
     name: {{ awx_pod_name }}_memcached
+    volumeMounts:
+    - name: memcached-socket
+      mountPath: "{{ memcached_socket_path }}"
   #
   # awx-web container
   #
@@ -114,14 +136,16 @@ spec:
       value: {{ awx_pg_port }}
     - name: DATABASE_HOST
       value: {{ awx_pg_hostname }}
-    - name: MEMCACHED_HOST
-      value: {{ awx_memcached_hostname }}
-    - name: MEMCACHED_PORT
-      value: {{ awx_memcached_port }}
     image: {{ awx_awxweb_image }}
     name: {{ awx_pod_name }}_awxweb
     workingDir: /var/lib/awx
     volumeMounts:
+    - name: supervisor-socket
+      mountPath: "/var/run/supervisor"
+    - name: rsyslog-socket
+      mountPath: "/var/run/awx-rsyslog"
+    - name: rsyslog-dir
+      mountPath: "/var/lib/awx/rsyslog"
     - mountPath: /var/lib/awx/projects:z
       name: awx-data-volume
     - mountPath: /var/run/redis:z
@@ -146,6 +170,8 @@ spec:
     - mountPath: /etc/tower/conf.d/credentials.py:z
       name: credentials-py
       readOnly: true
+    - name: memcached-socket
+      mountPath: "{{ awx_memcached_socket_path }}"
 {% if awx_host_ssl_certificate is defined %}
     - mountPath: /etc/nginx/awxweb.pem:z
       name: ssl_certificate
@@ -184,16 +210,18 @@ spec:
       value: {{ awx_pg_port }}
     - name: DATABASE_HOST
       value: {{ awx_pg_hostname }}
-    - name: MEMCACHED_HOST
-      value: {{ awx_memcached_hostname }}
-    - name: MEMCACHED_PORT
-      value: {{ awx_memcached_port }}
     image: {{ awx_awxtask_image }}
     name: {{ awx_pod_name }}_awxtask
     workingDir: /var/lib/awx
     securityContext:
       privileged: true
     volumeMounts:
+    - name: supervisor-socket
+      mountPath: "/var/run/supervisor"
+    - name: rsyslog-socket
+      mountPath: "/var/run/awx-rsyslog"
+    - name: rsyslog-dir
+      mountPath: "/var/lib/awx/rsyslog"
     - mountPath: /var/lib/awx/projects:z
       name: awx-data-volume
     - mountPath: /var/run/redis:z
@@ -218,6 +246,8 @@ spec:
     - mountPath: /etc/tower/conf.d/credentials.py:z
       name: credentials-py
       readOnly: true
+    - name: memcached-socket
+      mountPath: "{{ memcached_socket_path }}"
 {% if awx_host_ssl_certificate is defined %}
     - mountPath: /etc/nginx/awxweb.pem:z
       name: ssl_certificate
@@ -228,7 +258,7 @@ spec:
   #
   - command:
     - redis-server
-    - /usr/local/etc/redis/redis.conf
+    - {{ kubernetes_redis_config_mount_path }}
     workingDir: /data
     securityContext:
       allowPrivilegeEscalation: true
@@ -238,7 +268,7 @@ spec:
     volumeMounts:
     - mountPath: /var/run/redis:z
       name: redis-volume
-    - mountPath: /usr/local/etc/redis/redis.conf:z
+    - mountPath: {{ kubernetes_redis_config_mount_path }}:z
       name: redis-config
     image: {{ awx_redis_image }}
     name: {{ awx_pod_name }}_redis

--- a/templates/awx.yml.j2
+++ b/templates/awx.yml.j2
@@ -103,7 +103,7 @@ spec:
   - command:
     - memcached
     - -s
-    - {{ memcached_socket_path }}/{{ memcached_socket_filename }}
+    - {{ awx_memcached_socket_path }}/{{ awx_memcached_socket_filename }}
     - -a
     - 0666
     env:
@@ -111,7 +111,7 @@ spec:
     name: {{ awx_pod_name }}_memcached
     volumeMounts:
     - name: memcached-socket
-      mountPath: "{{ memcached_socket_path }}"
+      mountPath: "{{ awx_memcached_socket_path }}"
   #
   # awx-web container
   #
@@ -247,7 +247,7 @@ spec:
       name: credentials-py
       readOnly: true
     - name: memcached-socket
-      mountPath: "{{ memcached_socket_path }}"
+      mountPath: "{{ awx_memcached_socket_path }}"
 {% if awx_host_ssl_certificate is defined %}
     - mountPath: /etc/nginx/awxweb.pem:z
       name: ssl_certificate
@@ -258,7 +258,7 @@ spec:
   #
   - command:
     - redis-server
-    - {{ kubernetes_redis_config_mount_path }}
+    - {{ awx_kubernetes_redis_config_mount_path }}
     workingDir: /data
     securityContext:
       allowPrivilegeEscalation: true
@@ -268,7 +268,7 @@ spec:
     volumeMounts:
     - mountPath: /var/run/redis:z
       name: redis-volume
-    - mountPath: {{ kubernetes_redis_config_mount_path }}:z
+    - mountPath: {{ awx_kubernetes_redis_config_mount_path }}:z
       name: redis-config
     image: {{ awx_redis_image }}
     name: {{ awx_pod_name }}_redis

--- a/templates/credentials.py.j2
+++ b/templates/credentials.py.j2
@@ -1,23 +1,13 @@
 DATABASES = {
     'default': {
         'ATOMIC_REQUESTS': True,
-        'ENGINE': 'django.db.backends.postgresql',
+        'ENGINE': 'awx.main.db.profiled_pg',
         'NAME': "{{ awx_pg_database }}",
         'USER': "{{ awx_pg_username }}",
         'PASSWORD': "{{ awx_pg_password }}",
         'HOST': "{{ awx_pg_hostname }}",
         'PORT': "{{ awx_pg_port }}",
     }
-}
-
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': '{}:{}'.format("{{ awx_memcached_hostname }}", "{{ awx_memcached_port }}")
-    },
-    'ephemeral': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-    },
 }
 
 BROADCAST_WEBSOCKET_SECRET = "{{ broadcast_websocket_secret | b64encode }}"

--- a/templates/environment.sh.j2
+++ b/templates/environment.sh.j2
@@ -3,5 +3,3 @@ DATABASE_NAME={{ awx_pg_database }}
 DATABASE_HOST={{ awx_pg_hostname }}
 DATABASE_PORT={{ awx_pg_port }}
 DATABASE_PASSWORD={{ awx_pg_password | quote }}
-MEMCACHED_HOST={{ awx_memcached_hostname }}
-MEMCACHED_PORT={{ awx_memcached_port }}

--- a/templates/settings.py.j2
+++ b/templates/settings.py.j2
@@ -72,10 +72,7 @@ LOGGING['handlers']['management_playbooks'] = {'class': 'logging.NullHandler'}
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': '{}:{}'.format("{{ awx_memcached_hostname }}", "{{ awx_memcached_port }}")
-    },
-    'ephemeral': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'unix:/var/run/memcached/memcached.sock'
     },
 }
 


### PR DESCRIPTION
Fix missing awx_ prefixes

* memcached socket
* kubernetes redis

Added new variables to overwrite awxtask and awxweb in one go:

* awx_awx_version: 13.0.0
* awx_awx_image: docker.io/ansible/awx:{{ awx_awx_version }}

Kept backward compatible variables:

* awx_awxweb_{image, version}
* awx_awxtask_{image, version}