### PR TITLE
Make TOWER_URL_BASE configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,8 @@ awx_postgres_update: False
 awx_admin_user: admin
 awx_admin_password: password
 awx_server_email: 'root@localhost'
+# awx_hostname is set by default to fqdn, you can uncomment it here and change the hostname of the app if you have an alias or similar for awx
+# awx_hostname: otherhostnamethanfqdn.tld
 
 awx_pod_name: awx
 awx_pod_label: awx

--- a/templates/settings.py.j2
+++ b/templates/settings.py.j2
@@ -11,9 +11,9 @@ SYSTEM_TASK_ABS_CPU = {{ ((awx_task_cpu_request|int / 1000) * 4)|int }}
 SYSTEM_TASK_ABS_MEM = {{ ((awx_task_mem_request|int * 1024) / 100)|int }}
 
 {% if awx_host_ssl_certificate is defined %}
-TOWER_URL_BASE = "https://{{ ansible_fqdn }}:{{ awx_host_ssl_port }}"
+TOWER_URL_BASE = "https://{{ awx_hostname | default(ansible_fqdn) }}:{{ awx_host_ssl_port }}"
 {% else %}
-TOWER_URL_BASE = "http://{{ ansible_fqdn }}:{{ awx_host_port }}"
+TOWER_URL_BASE = "http://{{ awx_hostname | default(ansible_fqdn) }}:{{ awx_host_port }}"
 {% endif %}
 INSIGHTS_URL_BASE = "{{ awx_insights_url_base }}"
 INSIGHTS_AGENT_MIME = "{{ awx_insights_agent_mime }}"


### PR DESCRIPTION
Make TOWER_URL_BASE configurable -- calling it awx_hostname , this is useful if you have an alias or secondary a-record pointing to the server that is used for awx